### PR TITLE
Switchable style for scale intervals

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,9 +114,7 @@
                     Show intervals as:
                     <span id="interval-styles">
                         <a href='javascript:void(0)' id='arc'>Arcs</a> /
-                        <!-- TODO: shallow "gear teeth" sprinkled on a circle
-                        <a href='javascript:void(0)' id='gear'>Gear</a> /
-                        -->
+                        <a href='javascript:void(0)' id='gear'>Stalks</a> /
                         <a href='javascript:void(0)' id='pie'>Wedges</a>
                     </span>
                 </span> 

--- a/index.html
+++ b/index.html
@@ -110,7 +110,15 @@
                 <span class = 'category'><br>
                     Category: <span id='category'></span><br>
                     Root: <a href='javascript:void(0)' id='decrease-root' style='color: #ffffff'>&#8681;</a> / <a href='javascript:void(0)' id='increase-root'>&#8679;</a><br>
-                    Show: <a href='javascript:void(0)' id='flat'>Flats</a> / <a href='javascript:void(0)' id='sharp'>Sharps</a>
+                    Show: <a href='javascript:void(0)' id='flat'>Flats</a> / <a href='javascript:void(0)' id='sharp'>Sharps</a><br>
+                    Show intervals as:
+                    <span id="interval-styles">
+                        <a href='javascript:void(0)' id='arc'>Arcs</a> /
+                        <!-- TODO: shallow "gear teeth" sprinkled on a circle
+                        <a href='javascript:void(0)' id='gear'>Gear</a> /
+                        -->
+                        <a href='javascript:void(0)' id='pie'>Wedges</a>
+                    </span>
                 </span> 
             </div>
         </div>

--- a/src/scales.js
+++ b/src/scales.js
@@ -560,6 +560,11 @@ function createPaths(intervals, group, size, distance){
     group.add(pieStyleGroup);
     scene.userData.styledIntervals.push( pieStyleGroup );
 
+    var gearStyleGroup =  new THREE.Group();
+    gearStyleGroup.name = 'gear-intervals';
+    group.add(gearStyleGroup);
+    scene.userData.styledIntervals.push( gearStyleGroup );
+
     for(let i = 0; i < intervals.length; i++) {
 
         let start = noteCounter;
@@ -597,6 +602,33 @@ function createPaths(intervals, group, size, distance){
             new THREE.Vector2(v1.x, v1.y)
         );
         pieStyleGroup.add(c);
+
+        // TODO: Draw gear-style intervals into a dedicated group
+        // This should be a circular arc with a pointy half-tooth at start and end: \_____/ \_____/
+        // Instead, this just draws a thicker version of the default 'arcs'
+        let toothOffset = 0.1;
+        let sArcStart = new THREE.Spherical(minRadius, getRotation(start + toothOffset), - Math.PI / 2);
+        let sArcMid = new THREE.Spherical(maxRadius, (getRotation(start)+getRotation(end))/2, - Math.PI / 2);
+        let sArcEnd = new THREE.Spherical(minRadius, getRotation(end - toothOffset), - Math.PI / 2);
+        let vArcStart = new THREE.Vector3().setFromSpherical(sArcStart);
+        let vArcMid = new THREE.Vector3().setFromSpherical(sArcMid);
+        let vArcEnd = new THREE.Vector3().setFromSpherical(sArcEnd);
+        /* These "pins" are kind of an interesting alternative.
+        c = createCurve(
+            new THREE.Vector2(v1.x, v1.y),
+            new THREE.Vector2(vArcStart.x - v1.x, vArcStart.y - v1.y),
+            //new THREE.Vector2(vArcStart.x - (v1.x/2), vArcStart.y - (v1.y/2)),
+            new THREE.Vector2(vArcStart.x, vArcStart.y)
+            //new THREE.Vector2(vArcMid.x * 2.0, vArcMid.y * 2.0),
+            //new THREE.Vector2(vArcEnd.x, vArcEnd.y)
+        );
+        */
+        c = createCurve(
+            new THREE.Vector2(vArcStart.x, vArcStart.y),
+            new THREE.Vector2(vArcMid.x, vArcMid.y),
+            new THREE.Vector2(vArcEnd.x, vArcEnd.y)
+        );
+        gearStyleGroup.add(c);
 
         let dummy = new THREE.Mesh();
         dummy.position.copy(vLabel);


### PR DESCRIPTION
I really like this visualization, but I'd love to be able to switch the shapes/styles used to show intervals, as I think the resulting shapes will work better for some viewers.

Here are a couple of initial ideas to see what you think. I'd really like to try more of a "gear" style display, drawing circular arcs with small triangular teeth at each note of the scale. But I don't know how to wrangle `three.js` that well, so I'm hoping you might be able to run with this.

In terms of implementation, I started with more dynamic drawing, but once I realized how you're pre-drawing all the scales, I decided to follow suit, building a series of groups for each rendering style, then hiding all but one. This should be easy to extend with more (or different) styles as needed.